### PR TITLE
ram expansion unit REU

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Load first program from Disk:<br>
 LOAD"*",8<br>
 RUN<br>
 
+## emulated RAM Expansion Unit REU 1750
+For those programs the require a [RAM Expansion Unit (REU)](https://en.wikipedia.org/wiki/Commodore_REU) it can be activated by OSD on demand.<br>
+Playing [Sonic the Hedgehog](https://csdb.dk/release/?id=212190).<br>
+Enable REU.<br>
+Select first Disk Image and load the PRG.<br>
+**Important**: Disable Dolphin Dos 2 Speedloader by typing:<br> 
+[@XF- (RETURN)](https://project64.c64.org/hw/dolphindos.txt) <br>	
+Then type RUN (RETURN)<br>	
+When asked select the 'compatibility mode' for loading the full game as Dolphin DOS isn't compatible with Sonic's build in speedloader.<br>	
+
 ## Push Button utilization
 * S2 Reset (for Flasher)<br>
 * S1 reserved <br>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Features:
 * Joystick emulation on Keyboard Numpad<br>
 * [Dualshock 2 Controller Gamepad](https://en.wikipedia.org/wiki/DualShock) as Joystick<br>
 * emulated [1541 Diskdrive](https://en.wikipedia.org/wiki/Commodore_1541) on FAT/extFAT microSD card with [Userport](https://www.c64-wiki.com/wiki/User_Port) parallel bus [Speedloader Dolphin DOS](https://www.c64-wiki.de/wiki/Dolphin_DOS)<br>
+* emulated [RAM Expansion Unit (REU)](https://en.wikipedia.org/wiki/Commodore_REU)<br>
 * On Screen Display (OSD) for configuration and D64 / G64 image selection<br>
 
 <font color="red">HID interfaces aligned in pinmap and control to match</font> [MiSTeryNano project's bl616 misterynano_fw](https://github.com/harbaum/MiSTeryNano/tree/main/bl616/misterynano_fw).<br> Basically BL616 µC acts as USB host for a USB devices and OSD controller using a [SPI communication protocol](https://github.com/harbaum/MiSTeryNano/blob/main/SPI.md).<br>Have a look MiSTeryNano readme chapter 'Installation of the MCU firmware' to get an idea how to install the needed Firmware.
@@ -45,6 +46,7 @@ invoke by F12 keypress<br>
 * Scanlines<br>
 * c1541 Disk write protetcion<br>
 * HID device selection for Joystick Port 1 and Port 2<br>
+* REU configuration
 
 ## Gamecontrol Joystick support
 legacy D9 Digital Joystick<br>

--- a/src/fpga64_sid_iec.vhd
+++ b/src/fpga64_sid_iec.vhd
@@ -806,12 +806,7 @@ cass_write <= cpuIO(3);
 ramDout <= cpuDo;
 ramAddr <= systemAddr;
 ramWE   <= systemWe when sysCycle >= CYCLE_CPU0 else '0';
---ramCE   <= cs_ram when sysCycle = CYCLE_VIC0 or cpu_cyc = '1' else '0';
-
---working
-ramCE <= cs_ram when (sysCycle = CYCLE_VIC0) or
-                     (sysCycle > CYCLE_CPU0 and sysCycle <  CYCLE_CPUF and cs_ram = '1') or
-					 (sysCycle = CYCLE_CPUC and (io_enable = '1' or cs_ram = '1')) else '0';
+ramCE   <= cs_ram when sysCycle = CYCLE_VIC0 or cpu_cyc = '1' else '0';
 
 cpu_cyc <= '1' when 
 				(sysCycle = CYCLE_CPU0 and turbo_m(0) = '1' and cs_ram = '1' ) or

--- a/src/fpga64_sid_iec.vhd
+++ b/src/fpga64_sid_iec.vhd
@@ -663,7 +663,7 @@ port map (
   comb_wave_l => '0',
   comb_wave_r => '0',
 
-  extfilter_en => '1',
+  extfilter_en => sid_filter(0),
 
   start_iter => clk_1MHz_en,
   std_logic_vector(sample_left) => audio_l,

--- a/src/fpga64_sid_iec.vhd
+++ b/src/fpga64_sid_iec.vhd
@@ -809,8 +809,9 @@ ramWE   <= systemWe when sysCycle >= CYCLE_CPU0 else '0';
 --ramCE   <= cs_ram when sysCycle = CYCLE_VIC0 or cpu_cyc = '1' else '0';
 
 --working
-ramCE <= cs_ram when (sysCycle >= CYCLE_VIC0 and sysCycle <= CYCLE_VIC3) or
-                     (sysCycle >  CYCLE_CPU0 and sysCycle <  CYCLE_CPUF and cs_ram = '1') else '0';
+ramCE <= cs_ram when (sysCycle = CYCLE_VIC0) or
+                     (sysCycle > CYCLE_CPU0 and sysCycle <  CYCLE_CPUF and cs_ram = '1') or
+					 (sysCycle = CYCLE_CPUC and (io_enable = '1' or cs_ram = '1')) else '0';
 
 cpu_cyc <= '1' when 
 				(sysCycle = CYCLE_CPU0 and turbo_m(0) = '1' and cs_ram = '1' ) or

--- a/src/misc/sysctrl.v
+++ b/src/misc/sysctrl.v
@@ -29,7 +29,7 @@ module sysctrl (
   // values that can be configured by the user
   output reg [1:0]  system_chipset,
   output reg	    system_memory,
-  output reg	    system_video,
+  output reg [1:0]  system_reu_cfg,
   output reg [1:0]  system_reset,
   output reg [1:0]  system_scanlines,
   output reg [1:0]  system_volume,
@@ -63,7 +63,7 @@ always @(posedge clk) begin
       // will very likely override these early
       system_chipset <= 2'b0;
       system_memory <= 1'b0;
-      system_video <= 1'b0;   
+      system_reu_cfg <= 2'b00;
       system_scanlines <= 2'b00;
       system_volume <= 2'b10;
       system_wide_screen <= 1'b0;
@@ -116,8 +116,8 @@ always @(posedge clk) begin
                     if(id == "C") system_chipset <= data_in[1:0];      // unused presently
                     // Value "M": 
                     if(id == "M") system_memory <= data_in[0];         // unused presently
-                    // Value "V":
-                    if(id == "V") system_video <= data_in[0];         // unused presently
+                    // Value "V": REU cfg: none, 512K, 2MB (512KB wrap), 16MB
+                    if(id == "V") system_reu_cfg <= data_in[1:0];
                     // Value "R": coldboot(3), reset(1) or run(0)
                     if(id == "R") system_reset <= data_in[1:0];
                     // Value "S": scanlines none(0), 25%(1), 50%(2) or 75%(3)

--- a/src/misc/sysctrl.v
+++ b/src/misc/sysctrl.v
@@ -29,14 +29,19 @@ module sysctrl (
   // values that can be configured by the user
   output reg [1:0]  system_chipset,
   output reg	    system_memory,
-  output reg [1:0]  system_reu_cfg,
+  output reg        system_reu_cfg,
   output reg [1:0]  system_reset,
   output reg [1:0]  system_scanlines,
   output reg [1:0]  system_volume,
   output reg	    system_wide_screen,
   output reg [1:0]  system_floppy_wprot,
   output reg [2:0]  system_port_1,
-  output reg [2:0]  system_port_2
+  output reg [2:0]  system_port_2,
+  output reg [1:0]  system_dos_sel,
+  output reg        system_1541_reset,
+  output reg        system_audio_filter,
+  output reg [1:0]  system_turbo_mode,
+  output reg [1:0]  system_turbo_speed
 
 );
 
@@ -63,13 +68,18 @@ always @(posedge clk) begin
       // will very likely override these early
       system_chipset <= 2'b0;
       system_memory <= 1'b0;
-      system_reu_cfg <= 2'b00;
+      system_reu_cfg <= 1'b0;
       system_scanlines <= 2'b00;
       system_volume <= 2'b10;
       system_wide_screen <= 1'b0;
       system_floppy_wprot <= 2'b00;
-      system_port_1 <= 3'b000;
-      system_port_2 <= 3'b001;
+      system_port_1 <= 3'b011;
+      system_port_2 <= 3'b000;
+      system_dos_sel <= 2'b00;
+      system_1541_reset <= 1'b0;
+      system_audio_filter <= 1'b1;
+      system_turbo_mode <= 2'b00;
+      system_turbo_speed <= 2'b00;
 
    end else begin
       int_ack <= 8'h00;
@@ -116,8 +126,8 @@ always @(posedge clk) begin
                     if(id == "C") system_chipset <= data_in[1:0];      // unused presently
                     // Value "M": 
                     if(id == "M") system_memory <= data_in[0];         // unused presently
-                    // Value "V": REU cfg: none, 512K, 2MB (512KB wrap), 16MB
-                    if(id == "V") system_reu_cfg <= data_in[1:0];
+                    // Value "V": REU cfg: off, on
+                    if(id == "V") system_reu_cfg <= data_in[0];
                     // Value "R": coldboot(3), reset(1) or run(0)
                     if(id == "R") system_reset <= data_in[1:0];
                     // Value "S": scanlines none(0), 25%(1), 50%(2) or 75%(3)
@@ -132,6 +142,16 @@ always @(posedge clk) begin
                     if(id == "Q") system_port_1 <= data_in[2:0];
                     // Joystick port 2 input device selection
                     if(id == "J") system_port_2 <= data_in[2:0];
+                    // DOS system
+                    if(id == "D") system_dos_sel <= data_in[1:0];
+                    // c1541 reset
+                    if(id == "Z") system_1541_reset <= data_in[0];
+                    // sid audio filter
+                    if(id == "U") system_audio_filter <= data_in[0];
+                    // turbo mode
+                    if(id == "X") system_turbo_mode <= data_in[1:0];
+                    // turbo speed
+                    if(id == "Y") system_turbo_speed <= data_in[1:0];
                 end
             end
 

--- a/src/reu.v
+++ b/src/reu.v
@@ -1,0 +1,214 @@
+//
+//	REU implementation.
+// (C)2021 Alexey Melnikov
+//
+
+module reu
+(
+	input             clk,
+	input             reset,
+	input       [1:0] cfg, //none, 512K, 2MB (512KB wrap), 16MB
+
+	output reg        dma_req,
+
+	input             dma_cycle,
+	output reg [15:0] dma_addr,
+	output reg  [7:0] dma_dout,
+	input       [7:0] dma_din,
+	output            dma_we,
+	
+	input             ram_cycle,
+	output reg [24:0] ram_addr,
+	output reg  [7:0] ram_dout,
+	input       [7:0] ram_din,
+	output reg        ram_we,
+	
+	input      [15:0] cpu_addr,
+	input       [7:0] cpu_dout,
+	output reg  [7:0] cpu_din,
+	input             cpu_we,
+	input             cpu_cs,
+
+	output reg        irq
+);
+
+reg ff00_wr;
+always @(posedge clk) begin
+	reg old_we;
+	
+	old_we <= cpu_we;
+	ff00_wr <= 0;
+	if(~old_we && cpu_we && cpu_addr == 'hFF00) ff00_wr <= 1;
+end
+
+localparam STATE_IDLE     = 0;
+localparam STATE_EVAL     = 1;
+localparam STATE_PROC_C64 = 2;
+localparam STATE_PROC_RAM = 3;
+
+reg  [19:0] op;
+reg   [2:0] stage;
+wire [19:0] op_cur = op >> (stage*4);
+wire        op_dev = op_cur[0];   // 0: C64, 1: RAM
+wire        op_dat = op_cur[1];   // storage
+wire  [1:0] op_act = op_cur[3:2]; // 0: read, 1: write, 2: verify, 3: end
+
+reg dma_we_r;
+assign dma_we = dma_we_r & dma_cycle;
+
+always @(posedge clk) begin
+	reg        old_cs;
+	reg  [1:0] state;
+	reg  [3:0] cnt;
+	reg  [7:0] data[2];
+	reg [15:0] addr_c64, addr_c64_r;
+	reg [23:0] addr_ram, addr_ram_r;
+	reg [15:0] length, length_r;
+	reg  [7:0] cmd;
+	reg  [7:0] intr;
+	reg  [7:0] ctl;
+	reg [23:0] addr_mask;
+	reg  [7:0] status;
+	reg        error;
+	
+	irq <= (|(status[6:5] & intr[6:5])) & intr[7];
+
+	error = !op_act[0] && data[0] != data[1];
+	addr_mask = ((cfg == 1) ? 24'h7FFFF : (cfg == 2) ? 24'h1FFFFF : 24'hFFFFFF);
+
+	old_cs <= cpu_cs;
+
+	if(reset || !cfg) begin
+		status     <= 0;
+		cmd        <= 'h10;
+		addr_c64   <= 0;
+		addr_c64_r <= 0;
+		addr_ram   <= 0;
+		addr_ram_r <= 0;
+		length     <= 0;
+		length_r   <= 0;
+		intr       <= 0;
+		ctl        <= 0;
+		dma_req    <= 0;
+		dma_we_r   <= 0;
+		ram_we     <= 0;
+		cpu_din    <= 'hFF;
+		state      <= STATE_IDLE;
+	end
+	else begin
+		if(~dma_req & ~old_cs & cpu_cs) begin
+			if(cpu_we) begin
+				case(cpu_addr[4:0])
+					 1:       cmd             <= cpu_dout;
+					 2: begin addr_c64[7:0]   <= cpu_dout; addr_c64_r[7:0]   <= cpu_dout; end
+					 3: begin addr_c64[15:8]  <= cpu_dout; addr_c64_r[15:8]  <= cpu_dout; end
+					 4: begin addr_ram[7:0]   <= cpu_dout; addr_ram_r[7:0]   <= cpu_dout; end
+					 5: begin addr_ram[15:8]  <= cpu_dout; addr_ram_r[15:8]  <= cpu_dout; end
+					 6: begin addr_ram[23:16] <= cpu_dout; addr_ram_r[23:16] <= cpu_dout; end
+					 7: begin length[7:0]     <= cpu_dout; length_r[7:0]     <= cpu_dout; end
+					 8: begin length[15:8]    <= cpu_dout; length_r[15:8]    <= cpu_dout; end
+					 9:       intr            <= cpu_dout;
+					10:       ctl             <= cpu_dout;
+				endcase
+			end
+			else begin
+				case(cpu_addr[4:0])
+					 0: begin cpu_din <= {irq, status[6:5], 1'b1, 4'b0000}; status <= 0; end
+					 1: cpu_din <= cmd;
+					 2: cpu_din <= addr_c64[7:0];
+					 3: cpu_din <= addr_c64[15:8];
+					 4: cpu_din <= addr_ram[7:0];
+					 5: cpu_din <= addr_ram[15:8];
+					 6: cpu_din <= addr_ram[23:16] | ~addr_mask[23:16];
+					 7: cpu_din <= length[7:0];
+					 8: cpu_din <= length[15:8];
+					 9: cpu_din <= {intr[7:5],5'h1F};
+					10: cpu_din <= {ctl[7:6],6'h3F};
+				default: cpu_din <= 'hFF;
+				endcase
+			end
+		end
+	
+		case(state)
+			STATE_IDLE:
+				if(cmd[7] & (cmd[4] | ff00_wr)) begin
+					case(cmd[1:0])
+						0: op <= 'b1100_1100_1100_0101_0000; // C64 --> RAM
+						1: op <= 'b1100_1100_1100_0100_0001; // C64 <-- RAM
+						2: op <= 'b1100_0110_0101_0000_0011; // C64 <-> RAM
+						3: op <= 'b1100_1100_1000_0000_0011; // C64 =?= RAM
+					endcase
+					dma_req    <= 1;
+					stage      <= 0;
+					state      <= STATE_EVAL;
+					addr_ram   <= addr_ram & addr_mask;
+					addr_ram_r <= addr_ram_r & addr_mask;
+				end
+
+			STATE_EVAL:
+				begin
+					cnt <= 0;
+					if(op_act[1]) begin
+						if(~ctl[7]) addr_c64 <= addr_c64 + 1'd1;
+						if(~ctl[6]) addr_ram <= (cfg == 2) ? {addr_ram[20:19], addr_ram[18:0] + 1'd1} : ((addr_ram + 1'd1) & addr_mask);
+						stage <= 0;
+						if(length == 1 || error) begin
+							if(cmd[5]) begin
+								addr_ram <= addr_ram_r;
+								addr_c64 <= addr_c64_r;
+								length   <= length_r;
+							end
+							status[6] <= 1;
+							if(error) status[5] <= 1;
+							cmd[4]    <= 1;
+							cmd[7]    <= 0;
+							dma_req   <= 0;
+							state     <= STATE_IDLE;
+						end
+						else length  <= length - 1'd1;
+					end
+					else if(op_dev) begin
+						if (~ram_cycle) begin
+							ram_addr  <= {1'b1, addr_ram};
+							ram_we    <= op_act[0];
+							ram_dout  <= data[op_dat];
+							state     <= STATE_PROC_RAM;
+						end
+					end
+					else begin
+						if(~dma_cycle) begin
+							dma_addr  <= addr_c64;
+							dma_we_r  <= op_act[0];
+							dma_dout  <= data[op_dat];
+							state     <= STATE_PROC_C64;
+						end
+					end
+				end
+
+			STATE_PROC_RAM:
+				if(ram_cycle) begin
+					cnt    <= cnt + 1'd1;
+					if(&cnt[1:0]) begin
+						data[op_dat] <= ram_din;
+						ram_we       <= 0;
+						stage        <= stage + 1'd1;
+						state        <= STATE_EVAL;
+					end
+				end
+
+			STATE_PROC_C64:
+				if(dma_cycle) begin
+					cnt <= cnt + 1'd1;
+					if(&cnt[3:0]) begin
+						dma_addr     <= 0; // make sure we won't read some device's data while idling.
+						dma_we_r     <= 0;
+						data[op_dat] <= dma_din;
+						stage        <= stage + 1'd1;
+						state        <= STATE_EVAL;
+					end
+				end
+		endcase
+	end
+end
+
+endmodule

--- a/src/tang_nano_20k_c64_top.vhd
+++ b/src/tang_nano_20k_c64_top.vhd
@@ -508,7 +508,7 @@ end process;
 -- RAM is scrambled by xor'ing adress lines 2 and 3 with the scramble bits
 dram_addr_s <= dram_addr(21 downto 4) & (dram_addr(3 downto 2) xor ram_scramble) & dram_addr(1 downto 0);
 
-addr <= (B"100000_00000000_00000000" or reu_ram_addr(21 downto 0)) when ext_cycle = '1' else dram_addr_s;
+addr <= ((B"100000_00000000_0000000" or reu_ram_addr(20 downto 0)) & '0') when ext_cycle = '1' else dram_addr_s;
 cs <= reu_ram_ce when ext_cycle = '1' else ram_ce;
 we <= reu_ram_we when ext_cycle = '1' else ram_we;
 din <= ("00000000" & reu_ram_dout) when ext_cycle = '1' else ("00000000" & std_logic_vector(sdram_data));

--- a/src/tang_nano_20k_c64_top.vhd
+++ b/src/tang_nano_20k_c64_top.vhd
@@ -508,8 +508,8 @@ end process;
 
 -- RAM is scrambled by xor'ing adress lines 2 and 3 with the scramble bits
 dram_addr_s <= dram_addr(21 downto 4) & (dram_addr(3 downto 2) xor ram_scramble) & dram_addr(1 downto 0);
--- REU muxer
-addr <= reu_ram_addr(21 downto 0) when ext_cycle = '1' else dram_addr_s;
+
+addr <= (B"000001_00000000_00000000" or reu_ram_addr(21 downto 0)) when ext_cycle = '1' else dram_addr_s; -- REU memory start's at 0x10000 in dram
 cs <= reu_ram_ce when ext_cycle = '1' else ramCE;
 we <= reu_ram_we when ext_cycle = '1' else ramWe;
 din <= ("00000000" & reu_ram_dout) when ext_cycle = '1' else ("00000000" & std_logic_vector(ramDataOut(7 downto 0)));

--- a/src/tang_nano_20k_c64_top.vhd
+++ b/src/tang_nano_20k_c64_top.vhd
@@ -831,7 +831,7 @@ begin
   end if;
 end process;
 
-reu_oe  <= IOF and reu_cfg(1) and reu_cfg(0);
+reu_oe  <= IOF and (reu_cfg(1) or reu_cfg(0));
 reu_ram_ce <= not ext_cycle_d and ext_cycle and dma_req;
 
 reu: entity work.reu

--- a/src/tang_nano_20k_c64_top.vhd
+++ b/src/tang_nano_20k_c64_top.vhd
@@ -220,6 +220,9 @@ signal reu_oe         : std_logic;
 signal reu_ram_ce     : std_logic;
 signal io_data        : unsigned(7 downto 0);
 signal db9_joy        : std_logic_vector(5 downto 0);
+signal sid_filter     : std_logic_vector(1 downto 0) := "11";
+signal turbo_mode     : std_logic_vector(1 downto 0) := (others => '0');
+signal turbo_speed    : std_logic_vector(1 downto 0) := (others => '0');
 
 component CLKDIV
     generic (
@@ -703,8 +706,11 @@ module_inst: entity work.sysctrl
   system_floppy_wprot => system_floppy_wprot,
   system_port_1     => port_1_sel,  -- Joystick port 1 input device selection 
   system_port_2     => port_2_sel,  -- Joystick port 2 input device selection 
-  system_dos_sel    => dos_sel,
+  system_dos_sel    => open,
   system_1541_reset => c1541_osd_reset,
+  system_audio_filter => sid_filter(0),
+  system_turbo_mode   => turbo_mode,
+  system_turbo_speed  => turbo_speed,
 
   int_out_n         => m0s(4),
   int_in            => std_logic_vector(unsigned'("0000" & sdc_int & '0' & hid_int & '0')),
@@ -740,8 +746,8 @@ fpga64_sid_iec_inst: entity work.fpga64_sid_iec
   refresh      => idle,
 
   cia_mode     => '0',
-  turbo_mode   => "00",
-  turbo_speed  => "00",
+  turbo_mode   => turbo_mode,
+  turbo_speed  => turbo_speed,
 
   ntscMode     => ntscMode,
   hsync        => hsync,
@@ -787,7 +793,7 @@ fpga64_sid_iec_inst: entity work.fpga64_sid_iec
   --SID
   audio_l      => audio_data_l,
   audio_r      => audio_data_r,
-  sid_filter   => (others => '0'),
+  sid_filter   => sid_filter,
   sid_ver      => (others => '0'),
   sid_mode     => (others => '0'),
   sid_cfg      => (others => '0'),

--- a/tang_nano_20k_c64.gprj
+++ b/tang_nano_20k_c64.gprj
@@ -34,6 +34,7 @@
         <File path="src/misc/video_analyzer.v" type="file.verilog" enable="1"/>
         <File path="src/misc/ws2812.v" type="file.verilog" enable="1"/>
         <File path="src/mos6526.v" type="file.verilog" enable="1"/>
+        <File path="src/reu.v" type="file.verilog" enable="1"/>
         <File path="src/sdram.v" type="file.verilog" enable="1"/>
         <File path="src/c1541/c1541_logic.vhd" type="file.vhdl" enable="1"/>
         <File path="src/c1541/c1541_sd.vhd" type="file.vhdl" enable="1"/>


### PR DESCRIPTION
RAM Expansion Unit REU 1750 (512k) added
c1541 Reset via OSD added

Games like Sonic the Hedgehog make use of REU.
 
Note: This release requires temporarily a dedicated bl616 firmware release !

There are a number of already prepared OSD entries that are not yet fully implemented and don't have a proper function yet (1541 DOS selection, Turbo modes and speed.  